### PR TITLE
Embrace Heroku again and put server URL in .env

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node server/lib/server/index.js

--- a/client/src/services/Network.ts
+++ b/client/src/services/Network.ts
@@ -33,7 +33,7 @@ export default class Network {
     const protocol = window.location.protocol.replace('http', 'ws')
     const endpoint =
       process.env.NODE_ENV === 'production'
-        ? process.env.REACT_APP_SERVER_URL
+        ? import.meta.env.VITE_SERVER_URL
         : `${protocol}//${window.location.hostname}:2567`
     this.client = new Client(endpoint)
     this.joinLobbyRoom().then(() => {

--- a/client/src/services/Network.ts
+++ b/client/src/services/Network.ts
@@ -33,7 +33,7 @@ export default class Network {
     const protocol = window.location.protocol.replace('http', 'ws')
     const endpoint =
       process.env.NODE_ENV === 'production'
-        ? `wss://skyoffice.onrender.com/`
+        ? process.env.REACT_APP_SERVER_URL
         : `${protocol}//${window.location.hostname}:2567`
     this.client = new Client(endpoint)
     this.joinLobbyRoom().then(() => {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": ".eslintrc.js",
   "scripts": {
     "start": "cd server && ts-node-dev --project tsconfig.server.json --respawn --transpile-only index.ts",
+    "heroku-postbuild": "yarn && cd types && yarn && cd ../server && tsc --project tsconfig.server.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
There's a huge response delay when using Render servers, so we're switching back to Heroku (using the [Heroku Student Package](https://www.heroku.com/github-students)).

In this PR, the Procfile file and the `heroku-postbuild` command in package.json are added back. In addition, the server url is now encoded as an environment variable instead of hard coded in Network.ts.

In a follow-up PR, I will write in Readme about how to set up the .env etc.