### PR TITLE
Fix getRoomId type error

### DIFF
--- a/server/rooms/schema/OfficeState.ts
+++ b/server/rooms/schema/OfficeState.ts
@@ -49,7 +49,7 @@ export const whiteboardRoomIds = new Set<string>()
 const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 const charactersLength = characters.length
 
-function getRoomId() {
+function getRoomId(): string {
   let result = ''
   for (let i = 0; i < 12; i++) {
     result += characters.charAt(Math.floor(Math.random() * charactersLength))


### PR DESCRIPTION
This PR specifies `getRoomId` return type.

This error occurred during build process after #74:

```
rooms/schema/OfficeState.ts(52,10): error TS7023: 'getRoomId' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
error Command failed with exit code 2.
```